### PR TITLE
Fix timeouts not being caught correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build": "rm -rf node_modules && yarn install --production=true && tsc && zip -r --exclude=*terraform* ./grader.zip index.js node_modules/ && yarn install --production=false",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
-    "test-coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls"
+    "test": "TIMEOUT=1000 jest",
+    "test-coveralls": "TIMEOUT=1000 jest --coverage --coverageReporters=text-lcov | coveralls"
   },
   "dependencies": {
     "js-slang": "0.1.4",

--- a/src/__tests__/examples/chap1.ts
+++ b/src/__tests__/examples/chap1.ts
@@ -17,15 +17,20 @@ const validStudentPartial =
   `const f = i => i < 3 ? 1 : f(i-1) + f(i-2);`
 
 const invalidStudentRuntime =
-  `const f = i => f(i+1);`
+  `const f = i => f(j+1);`
 
 const invalidStudentSyntax =
   `const f = i => i === 0 ? 0 : i < 3 ? 1 : f(i-1) + f(i-2)`
 
+// Does not compute fast enough to exceed max call stacks, relies on timeout
+const invalidStudentTimeout =
+   `const f = i => i < -3 ? 0 : f(i+1) + f(i+2);`
+
 export const student: Student = {
   invalid: {
     runtime: invalidStudentRuntime,
-    syntax: invalidStudentSyntax
+    syntax: invalidStudentSyntax,
+    timeout: invalidStudentTimeout
   },
   valid: {
     correct: validStudentCorrect,

--- a/src/__tests__/examples/types.ts
+++ b/src/__tests__/examples/types.ts
@@ -11,6 +11,7 @@ export type Student = {
 type InvalidPrograms<Program> = {
   runtime: Program
   syntax: Program
+  timeout?: Program
 }
 
 type ValidPrograms = {

--- a/src/__tests__/test_chapt1.ts
+++ b/src/__tests__/test_chapt1.ts
@@ -47,7 +47,14 @@ test('grader OK, student runtimeError', async () => {
       location: 'student'
     }))
   })
-}, 30000)
+})
+
+test('grader OK, student timeoutError', async () => {
+  const results = await runAll(makeAwsEvent(grader.valid, student.invalid.timeout))
+  results.map(result => {
+    expect(result.resultType).toBe('timeout')
+  })
+}, 10000)
 
 test('grader OK, student syntaxError', async () => {
   const results = await runAll(makeAwsEvent(grader.valid, student.invalid.syntax))

--- a/src/__tests__/test_chapt1.ts
+++ b/src/__tests__/test_chapt1.ts
@@ -52,7 +52,11 @@ test('grader OK, student runtimeError', async () => {
 test('grader OK, student timeoutError', async () => {
   const results = await runAll(makeAwsEvent(grader.valid, student.invalid.timeout))
   results.map(result => {
-    expect(result.resultType).toBe('timeout')
+    expect(result.resultType).toBe('error')
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0]).toEqual({
+      errorType: 'timeout'
+    })
   })
 }, 10000)
 

--- a/src/__tests__/test_chapt1.ts
+++ b/src/__tests__/test_chapt1.ts
@@ -8,7 +8,7 @@ const makeAwsEvent = awsEventFactory({
     name: 'NONE',
     symbols: []
   },
-  globals: [[]]
+  globals: []
 })
 
 test('grader OK, student OK, correct', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,8 @@ export type Library = {
 
 /**
  * Output is the 'refined' version of a @type {Result}.
- *   OutputError - program raises a js-slang SourceError
+ *   OutputError - program raises an error
  *   OutputPass - program raises no errors
- *   OutputTimeout - program has run pass the TIMEOUT_DURATION
  */
 type Output = OutputPass | OutputError
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createContext, runInContext, Result as SourceResult } from 'js-slang'
 import { SourceError } from 'js-slang/dist/types'
 
-const TIMEOUT_DURATION = 20000
+const TIMEOUT_DURATION = process.env.NODE_ENV !== 'test' ? 20000 : 1000
 
 type AwsEvent = {
   graderPrograms: string[]
@@ -90,10 +90,7 @@ const run = async (chap: number, stdPrg: string, gdrPrg: string): Promise<Output
 }
 
 const catchTimeouts = (slangPromise: Promise<Result>): Promise<Result> => {
-  const timeoutDuration = process.env.NODE_ENV !== 'test'
-    ? TIMEOUT_DURATION
-    : 1000 // facilitate testing
-  return Promise.race([slangPromise, timeout(timeoutDuration)])
+  return Promise.race([slangPromise, timeout(TIMEOUT_DURATION)])
 }
 
 const timeout = (msDuration: number): Promise<TimeoutResult> => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createContext, runInContext, Result as SourceResult } from 'js-slang'
 import { SourceError } from 'js-slang/dist/types'
 
-const TIMEOUT_DURATION = process.env.NODE_ENV !== 'test' ? 20000 : 1000
+const TIMEOUT_DURATION = parseInt(process.env.TIMEOUT!, 10) // in milliseconds
 
 type AwsEvent = {
   graderPrograms: string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,24 +29,26 @@ export type Library = {
  *   OutputPass - program raises no errors
  *   OutputTimeout - program has run pass the TIMEOUT_DURATION
  */
-type Output = OutputError | OutputPass | OutputTimeout
-
-type OutputError = {
-  errors: Array<{
-    errorType: 'runtime' | 'syntax'
-    line?: number
-    location?: string
-  }>
-  resultType: 'error'
-}
+type Output = OutputPass | OutputError
 
 type OutputPass = {
   grade: number
   resultType: 'pass'
 }
 
-type OutputTimeout = {
-  resultType: 'timeout'
+type OutputError = {
+  errors: Array<ErrorFromSource | ErrorFromTimeout>
+  resultType: 'error'
+}
+
+type ErrorFromSource = {
+  errorType: 'runtime' | 'syntax'
+  line: number
+  location: string
+}
+
+type ErrorFromTimeout = {
+  errorType: 'timeout'
 }
 
 /**
@@ -80,7 +82,10 @@ const run = async (chap: number, stdPrg: string, gdrPrg: string): Promise<Output
   } else if (result.status === 'error') {
     return parseError(context.errors, stdPrg, gdrPrg)
   } else {
-    return { resultType: 'timeout' } // from timeout/1 in catchTimeouts/1
+    return {
+      errors: [ { errorType: 'timeout' } ],
+      resultType: 'error'
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export type Library = {
 }
 
 /**
- * Output is the 'refined' version of a Result.
+ * Output is the 'refined' version of a @type {Result}.
  *   OutputError - program raises a js-slang SourceError
  *   OutputPass - program raises no errors
  *   OutputTimeout - program has run pass the TIMEOUT_DURATION
@@ -53,8 +53,8 @@ type ErrorFromTimeout = {
 
 /**
  * Result is the 'raw' result of the js-slang interpreter running a
- * student/grader program. It will be transformed into a more 'refined' Output
- * to be returned to a backend.
+ * student/grader program. It will be transformed into a more 'refined'
+ * @type {Output} to be returned to a backend.
  */
 type Result = SourceResult | TimeoutResult
 


### PR DESCRIPTION
Resolves #14.

@tuesmiddt There is a minor change in the response API from grader to backend. Namely, there is a new error type for timeouts, separate from runtime and syntax errors. The response is still an array of `Output`s, where an `Output` has [this type definition](https://github.com/source-academy/grader/blob/55bcc128a70b0f5e1ee07674fc7b195a62c11025/src/index.ts#L32). 

An example:
```JSON
[
    {
        "grade": 30,
        "resultType": "pass"
    },
    {
        "grade": 50,
        "resultType": "pass"
    },
    {
        "errors": [
            {
                "errorType": "syntax",
                "line": 28,
                "location": "student"
            },
            {
                "errorType": "syntax",
                "line": 32,
                "location": "student"
            }
        ],
        "resultType": "error"
    },
    {
        "errors": [
            {
                "errorType": "timeout"
            }
        ],
        "resultType": "error"
    }
]
```