### PR TITLE
Fix type errors in building the deployment zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "test-coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls"
   },
   "dependencies": {
+    "@types/node": "^10.5.2",
     "js-slang": "0.1.4",
     "typescript": "^2.9.2"
   },
   "devDependencies": {
-    "@types/node": "^10.5.2",
     "coveralls": "^3.0.2",
     "jest": "^23.4.0",
     "ts-jest": "^23.0.0"


### PR DESCRIPTION
- We use `yarn install --production = true` to build the deployment zip
- As a result, `devDependencies` are not downloaded when `tsc` runs
- As a result, `tsc` has no access to `@types/node`
- And so there are type errors in the build process.