### PR TITLE
add __scan_canvas

### DIFF
--- a/src/__tests__/examples/curves.ts
+++ b/src/__tests__/examples/curves.ts
@@ -20,7 +20,7 @@ const validStudentWrong =
       return make_point(-t, math_sin(t * math_PI));
     }
 
-    (draw_connected(200))(forward_sine);
+    (draw_connected(200))(backward_sine);
     `
 
 export const student: Student = {
@@ -41,5 +41,7 @@ const validGrader = [
 `]
 
 export const grader: Grader = {
-    valid: validGrader
+    pixel: validGrader,
+    scan: validGrader
+
 }

--- a/src/__tests__/examples/curves.ts
+++ b/src/__tests__/examples/curves.ts
@@ -40,6 +40,15 @@ const validGrader = [
       ) ? 1 : 0;
 `]
 
+const scanGrader = [
+ `__scan_canvas(
+        draw_connected_squeezed_to_window,
+        300,
+        backward_sine,
+        50,
+      ) ? 1 : 0;
+`]
+
 export const grader: Grader = {
     pixel: validGrader,
     scan: validGrader

--- a/src/__tests__/test_curve_comparison.ts
+++ b/src/__tests__/test_curve_comparison.ts
@@ -145,14 +145,14 @@ test("", async () => {
 test("build compressed vertical test", async () => {
   var solution_point_array = draw_connected_full_view(3000)(unit_circle);
   var solutionBitmap = __drawCurve(solution_point_array, 300);
-  var results = __build_compressed_vertical(solutionBitmap, 300);
+  var results = __build_compressed_vertical(solutionBitmap);
   expect(results).toEqual(["010", "01010", "101", "01010", "010"].join("\n"));
 });
 
 test("build compressed horizontal test", async () => {
   var solution_point_array = draw_connected_full_view(3000)(unit_circle);
   var solutionBitmap = __drawCurve(solution_point_array, 300);
-  var results = __build_compressed_horizontal(solutionBitmap, 300);
+  var results = __build_compressed_horizontal(solutionBitmap);
   expect(results).toEqual(["010", "01010", "101", "01010", "010"].join("\n"));
 });
 
@@ -168,13 +168,13 @@ test("build compressed horizontal test", async () => {
 test("build compressed vertical sin test", async () => {
   var solution_point_array = draw_connected(3000)(forward_sine);
   var solutionBitmap = __drawCurve(solution_point_array, 300);
-  var results = __build_compressed_vertical(solutionBitmap, 300);
+  var results = __build_compressed_vertical(solutionBitmap);
   expect(results).toEqual(["10", "010", "01","010", "10"].join("\n"));
 });
 
 test("build compressed horizontal sin test", async () => {
   var solution_point_array = draw_connected(3000)(forward_sine);
   var solutionBitmap = __drawCurve(solution_point_array, 20);
-  var results = __build_compressed_horizontal(solutionBitmap, 20);
+  var results = __build_compressed_horizontal(solutionBitmap);
   expect(results).toEqual(["101", "01010","010"].join("\n"));
 });

--- a/src/__tests__/test_curve_comparison.ts
+++ b/src/__tests__/test_curve_comparison.ts
@@ -141,3 +141,40 @@ test("", async () => {
   );
   expect(results).toEqual(false);
 });
+
+test("build compressed vertical test", async () => {
+  var solution_point_array = draw_connected_full_view(3000)(unit_circle);
+  var solutionBitmap = __drawCurve(solution_point_array, 300);
+  var results = __build_compressed_vertical(solutionBitmap, 300);
+  expect(results).toEqual(["010", "01010", "101", "01010", "010"].join("\n"));
+});
+
+test("build compressed horizontal test", async () => {
+  var solution_point_array = draw_connected_full_view(3000)(unit_circle);
+  var solutionBitmap = __drawCurve(solution_point_array, 300);
+  var results = __build_compressed_horizontal(solutionBitmap, 300);
+  expect(results).toEqual(["010", "01010", "101", "01010", "010"].join("\n"));
+});
+
+
+
+/*
+[ [ 1, 1, 1, 0, 0 ],
+  [ 0, 0, 1, 1, 1 ],
+  [ 0, 0, 0, 0, 1 ],
+  [ 0, 0, 1, 1, 1 ],
+  [ 1, 1, 1, 0, 0 ] ]
+*/
+test("build compressed vertical sin test", async () => {
+  var solution_point_array = draw_connected(3000)(forward_sine);
+  var solutionBitmap = __drawCurve(solution_point_array, 300);
+  var results = __build_compressed_vertical(solutionBitmap, 300);
+  expect(results).toEqual(["10", "010", "01","010", "10"].join("\n"));
+});
+
+test("build compressed horizontal sin test", async () => {
+  var solution_point_array = draw_connected(3000)(forward_sine);
+  var solutionBitmap = __drawCurve(solution_point_array, 20);
+  var results = __build_compressed_horizontal(solutionBitmap, 20);
+  expect(results).toEqual(["101", "01010","010"].join("\n"));
+});

--- a/src/__tests__/test_curves.ts
+++ b/src/__tests__/test_curves.ts
@@ -47,3 +47,17 @@ test('wrong answer', async () => {
   ])
 })
 
+test('scan grader correct', async () => {
+  const results = await runAll(makeAwsEvent(grader.scan, student.valid.correct))
+  expect(results).toEqual([
+      {'grade': 1, 'resultType': 'pass'}
+  ])
+})
+
+test('scan grader wrong', async () => {
+  const results = await runAll(makeAwsEvent(grader.scan, student.valid.wrong))
+  expect(results).toEqual([
+      {'grade': 0, 'resultType': 'pass'}
+  ])
+})
+

--- a/src/__tests__/test_curves.ts
+++ b/src/__tests__/test_curves.ts
@@ -34,14 +34,14 @@ const makeAwsEvent = awsEventFactory({
 })
 
 test('curve grader correct', async () => {
-  const results = await runAll(makeAwsEvent(grader.valid, student.valid.correct))
+  const results = await runAll(makeAwsEvent(grader.pixel, student.valid.correct))
   expect(results).toEqual([
       {'grade': 1, 'resultType': 'pass'}
   ])
 })
 
 test('wrong answer', async () => {
-  const results = await runAll(makeAwsEvent(grader.valid, student.valid.wrong))
+  const results = await runAll(makeAwsEvent(grader.pixel, student.valid.wrong))
   expect(results).toEqual([
       {'grade': 0, 'resultType': 'pass'}
   ])

--- a/src/graphics/curves_library.js
+++ b/src/graphics/curves_library.js
@@ -211,7 +211,7 @@ function __scan_canvas(draw_mode, num_points, solution_curve, resolution=300, ho
   if(vertical_lines) {
     result = result && (
       build_compressed_vertical(studentBitmap)
-        === build_compressed_horizontal(solutionBitmap)
+        === build_compressed_vertical(solutionBitmap)
     );
   }
   return result;

--- a/src/graphics/curves_library.js
+++ b/src/graphics/curves_library.js
@@ -201,34 +201,23 @@ function __scan_canvas(draw_mode, num_points, solution_curve, resolution=300, ho
   var studentBitmap = drawCurve(canvas, resolution);
   var solution_point_array = (draw_mode(num_points))(solution_curve);
   var solutionBitmap = drawCurve(solution_point_array, resolution);
-  const TOTAL_POINTS = resolution * resolution;
-  var base = 0;
-  var matched_points = 0;
-  for (var i = 0; i < resolution; i++) {
-    for (var j = 0; j < resolution; j++) {
-      if (studentBitmap[i][j] === 0 && solutionBitmap[i][j] === 0) {
-        continue;
-      }
-      base++;
-      if( studentBitmap[i][j] === solutionBitmap[i][j]) {
-        matched_points++;
-      }
-    }
+  var result = true;
+  if(horizontal_lines) {
+    result = result && (
+      build_compressed_horizontal(studentBitmap)
+        === build_compressed_horizontal(solutionBitmap)
+    );
   }
-
-  const test_accuracy = matched_points / base;
-  // Check fraction of correct points against accuracy tolerance
-  if (test_accuracy >= accuracy) {
-    return true;
-  } else {
-    // console.log(`Total points: ${base}`);
-    // console.log(`Matched points: ${matched_points}`);
-    // console.log(`Test accuracy: ${test_accuracy}`);
-    return false;
+  if(vertical_lines) {
+    result = result && (
+      build_compressed_vertical(studentBitmap)
+        === build_compressed_horizontal(solutionBitmap)
+    );
   }
+  return result;
 }
 
-function build_compressed_horizontal(bitmap, resolution) {
+function build_compressed_horizontal(bitmap) {
   var intermediate = bitmap.map((_, index) => {
     var row = bitmap.map(col => col[index]);
     return compress_array(row, '');
@@ -236,7 +225,7 @@ function build_compressed_horizontal(bitmap, resolution) {
   return compress_array(intermediate, '\n');
 }
 
-function build_compressed_vertical(bitmap, resolution) {
+function build_compressed_vertical(bitmap) {
   return compress_array(bitmap.map(arr => compress_array(arr, '')),'\n');
 }
 


### PR DESCRIPTION
Add the ability to use '__scan_canvas', which builds a compressed version of the canvas and compares that with the solution curve.

Compression works by removing sequential identical elements (tests are in test_curve_comparison)
Example: starting with
```
[ [ 1, 1, 1, 0, 0 ],
  [ 0, 0, 1, 1, 1 ],
  [ 0, 0, 0, 0, 1 ],
  [ 0, 0, 1, 1, 1 ],
  [ 1, 1, 1, 0, 0 ] ]
```
becomes after one pass (mapping on all the rows)
```
['10'
'01'
'01'
'01'
'10'
]
```
and then running again on the outer array:
```
"10
01
10"
```

Useful for comparing arbitrary shapes like "S" and "J" which may not be pixel-perfect.