### PR TITLE
Bump js-slang to v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ericandrewlewis/bitmap": "^1.0.0",
     "@types/node": "^10.5.2",
-    "js-slang": "0.1.7",
+    "js-slang": "0.1.10",
     "lodash": "4.17.10",
     "typescript": "^2.9.2"
   },

--- a/src/__tests__/examples/sounds.ts
+++ b/src/__tests__/examples/sounds.ts
@@ -90,10 +90,12 @@ const validGrader = [
             return 0;
         } else {}
 
-        const discipline = accumulate(function(t, final_marks) {
+        function accumulate_discipline(t, final_marks) {
             const has_discipline = (get_wave(some_sourcesound))(t) === 0;
             return has_discipline ? final_marks : 0;
-        }, 2, list(0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18));
+        }
+
+        const discipline = accumulate(accumulate_discipline, 2, list(0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18));
 
         return 1 + discipline;
     }
@@ -116,10 +118,13 @@ const validGrader = [
         } else {}
 
         const disciplined_sourcesound = sound_to_sourcesound(disciplined_sound);
-        const deductions = accumulate(function(t, final_marks) {
+
+        function accumulate_deductions(t, final_marks) {
             const has_discipline = (get_wave(disciplined_sourcesound))(t) === 0;
             return has_discipline ? final_marks : -1;
-        }, 0, list(0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18));
+        }
+
+        const deductions = accumulate(accumulate_deductions, 0, list(0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18));
 
         return 2 + deductions;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,9 +1876,9 @@ jest@^23.4.0:
     import-local "^1.0.0"
     jest-cli "^23.4.0"
 
-js-slang@0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.1.7.tgz#0c8045c659e7aa9b026281718de32ac5b5372511"
+js-slang@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-0.1.10.tgz#d081b896d5bbab34246e4bbb6d7d020b07ec72d6"
   dependencies:
     "@types/acorn" "^4.0.3"
     "@types/estree" "0.0.39"


### PR DESCRIPTION
- Fixes an issue with `for` loops when grading.