### PR TITLE
Bump dependencies via dependabot

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "fast-levenshtein": "^3.0.0",
-    "js-slang": "^1.0.28",
+    "js-slang": "^1.0.31",
     "lodash": "4.17.21",
     "node-canvas-webgl": "^0.2.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1673,11 +1673,10 @@ gl-wiretap@^0.6.2:
   resolved "https://registry.yarnpkg.com/gl-wiretap/-/gl-wiretap-0.6.2.tgz#e4aa19622831088fbaa7e5a18d01768f7a3fb07c"
   integrity sha512-fxy1XGiPkfzK+T3XKDbY7yaqMBmozCGvAFyTwaZA3imeZH83w7Hr3r3bYlMRWIyzMI/lDUvUMM/92LE2OwqFyQ==
 
-gl@^4.4.0, gl@^5.0.3, gl@^6.0.2:
+gl@^4.4.0, gl@^4.5.2, gl@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/gl/-/gl-6.0.2.tgz#685579732a19075e3acf4684edb1270278e551c7"
   integrity sha512-yBbfpChOtFvg5D+KtMaBFvj6yt3vUnheNAH+UrQH2TfDB8kr0tERdL0Tjhe0W7xJ6jR6ftQBluTZR9jXUnKe8g==
-
   dependencies:
     bindings "^1.5.0"
     bit-twiddle "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2364,10 +2364,10 @@ js-base64@^3.7.5:
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.5.tgz#21e24cf6b886f76d6f5f165bfcd69cc55b9e3fca"
   integrity sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==
 
-js-slang@^1.0.28:
-  version "1.0.28"
-  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-1.0.28.tgz#c7d554e7fa379e7641e6a50824ddba72ed296ff2"
-  integrity sha512-Vu5IZmThS+gGz1uwufVN7n4Zzxy2UilezqSYoBAf+EIOmKXlOPWY82YNZFlWud69guXoQT6y4/QVQCPYnqMTvA==
+js-slang@^1.0.31:
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/js-slang/-/js-slang-1.0.31.tgz#5dc79a3e0a4d0770fbddcafd5e0d278a4d8f6e00"
+  integrity sha512-nk8g6pEIC5fOO3LRa22tE6NK8Rseoefk5J9lQG+NV2HKPY0aw4ll45rA+CugtocaLARFw6lp9jK6ynsqM2XL5w==
   dependencies:
     "@babel/parser" "^7.19.4"
     "@joeychenofficial/alt-ergo-modified" "^2.4.0"


### PR DESCRIPTION
Also bumps js-slang manually to 1.0.31.

Resolves a couple security alerts.