### PR TITLE
Grade conductor questions via headless conductor runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
   "dependencies": {
+    "@sourceacademy/conductor": "^0.7.1",
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.13",
     "fast-levenshtein": "^3.0.0",
     "js-slang": "^1.0.85",
     "lodash": "4.17.21",
@@ -35,7 +37,8 @@
   },
   "jest": {
     "collectCoverageFrom": [
-      "src/index.ts"
+      "src/index.ts",
+      "src/conductor.ts"
     ],
     "moduleFileExtensions": [
       "ts",

--- a/scripts/smoke-conductor.cjs
+++ b/scripts/smoke-conductor.cjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * End-to-end smoke test for conductor grading.
+ *
+ * Runs the *built* grader (`build/conductor.js`) against a real, published
+ * Source Academy evaluator bundle (fetched from GitHub Pages), proving that a
+ * conductor question can be graded headless in Node. Requires network access
+ * and executes the downloaded evaluator bundle, so it is intentionally NOT part
+ * of `yarn test` / CI.
+ *
+ * Usage: yarn build && node scripts/smoke-conductor.cjs
+ */
+const path = require('node:path')
+
+const { runAllConductor } = require(path.join(__dirname, '..', 'build', 'conductor.js'))
+
+const event = {
+  library: { format: 'conductor', language: 'python3', evaluator: 'python3Default' },
+  prependProgram: '',
+  studentProgram: 'def double(n):\n    return n * 2\n',
+  postpendProgram: '',
+  testcases: [
+    { program: 'print(double(21))', answer: '42', score: 1 }, // expect pass
+    { program: 'print(double(5))', answer: '10', score: 2 }, // expect pass
+    { program: 'print(double(1))', answer: '999', score: 3 }, // expect fail (2 != 999)
+    { program: 'print(undefined_name)', answer: 'x', score: 4 }, // expect error
+  ],
+}
+
+runAllConductor(event)
+  .then(summary => {
+    console.log(JSON.stringify(summary, null, 2))
+    const [pass1, pass2, fail, error] = summary.results
+    const ok =
+      summary.maxScore === 10 &&
+      summary.totalScore === 3 &&
+      pass1.resultType === 'pass' &&
+      pass2.resultType === 'pass' &&
+      fail.resultType === 'fail' &&
+      error.resultType === 'error'
+    console.log(ok ? '\nSMOKE PASSED' : '\nSMOKE FAILED: unexpected results')
+    process.exit(ok ? 0 : 1)
+  })
+  .catch(err => {
+    console.error('SMOKE FAILED:', err)
+    process.exit(1)
+  })

--- a/src/__tests__/test_conductor.ts
+++ b/src/__tests__/test_conductor.ts
@@ -1,0 +1,128 @@
+import {
+  assembleProgram,
+  type ConductorProgramRunner,
+  gradeRun,
+  normalizeOutput,
+  runAllConductor,
+} from '../conductor'
+import { AwsEvent, ConductorLibrary, Testcase } from '../index'
+
+const conductorLibrary: ConductorLibrary = {
+  format: 'conductor',
+  language: 'python3',
+  evaluator: 'python3Default',
+}
+
+function event(overrides: Partial<AwsEvent> = {}): AwsEvent {
+  return {
+    library: conductorLibrary,
+    prependProgram: '',
+    studentProgram: '',
+    postpendProgram: '',
+    testcases: [],
+    ...overrides,
+  }
+}
+
+describe('assembleProgram', () => {
+  it('concatenates non-empty parts in order with newlines', () => {
+    const tc: Testcase = { program: 'C', answer: '', score: 1 }
+    expect(assembleProgram(event({ prependProgram: 'A', studentProgram: 'B' }), tc)).toBe('A\nB\nC')
+  })
+
+  it('drops empty prepend/postpend segments', () => {
+    const tc: Testcase = { program: 'print(x)', answer: '1', score: 1 }
+    expect(assembleProgram(event({ studentProgram: 'x = 1' }), tc)).toBe('x = 1\nprint(x)')
+  })
+})
+
+describe('normalizeOutput', () => {
+  it('strips trailing whitespace so a print newline still matches', () => {
+    expect(normalizeOutput('3\n')).toBe('3')
+    expect(normalizeOutput('hello \n\n')).toBe('hello')
+    expect(normalizeOutput('line1\nline2\n')).toBe('line1\nline2')
+  })
+})
+
+describe('gradeRun', () => {
+  const tc: Testcase = { program: 'print(3)', answer: '3', score: 2 }
+
+  it('passes when trimmed stdout matches the answer', () => {
+    expect(gradeRun({ output: '3\n', timedOut: false }, tc)).toEqual({
+      resultType: 'pass',
+      score: 2,
+    })
+  })
+
+  it('fails and reports expected/actual when stdout differs', () => {
+    expect(gradeRun({ output: '4\n', timedOut: false }, tc)).toEqual({
+      resultType: 'fail',
+      expected: '3',
+      actual: '4',
+    })
+  })
+
+  it('reports a runtime error when the run errored', () => {
+    expect(gradeRun({ output: '', error: 'NameError', timedOut: false }, tc)).toEqual({
+      resultType: 'error',
+      errors: [
+        {
+          errorType: 'runtime',
+          line: 0,
+          location: 'testcase',
+          errorLine: '',
+          errorExplanation: 'NameError',
+        },
+      ],
+    })
+  })
+
+  it('reports a timeout when the run did not settle', () => {
+    expect(gradeRun({ output: '', timedOut: true }, tc)).toEqual({
+      resultType: 'error',
+      errors: [{ errorType: 'timeout' }],
+    })
+  })
+
+  it('falls back to the result channel when there is no stdout', () => {
+    expect(
+      gradeRun(
+        { output: '', result: 42, timedOut: false },
+        { program: '', answer: '42', score: 1 },
+      ),
+    ).toEqual({ resultType: 'pass', score: 1 })
+  })
+})
+
+describe('runAllConductor', () => {
+  // Fake runner: pretends the evaluator prints the integer inside `print(<n>)`.
+  const echoingRunner: ConductorProgramRunner = program => {
+    const match = program.match(/print\((\d+)\)/)
+    return Promise.resolve({ output: `${match ? match[1] : ''}\n`, timedOut: false })
+  }
+
+  it('grades each testcase and aggregates the score', async () => {
+    const testcases: Testcase[] = [
+      { program: 'print(1)', answer: '1', score: 2 },
+      { program: 'print(9)', answer: '2', score: 3 },
+    ]
+
+    const summary = await runAllConductor(event({ testcases }), {
+      createRunner: async () => echoingRunner,
+    })
+
+    expect(summary.maxScore).toBe(5)
+    expect(summary.totalScore).toBe(2)
+    expect(summary.results).toEqual([
+      { resultType: 'pass', score: 2 },
+      { resultType: 'fail', expected: '2', actual: '9' },
+    ])
+  })
+
+  it('returns a zero-score empty summary when there are no testcases', async () => {
+    const summary = await runAllConductor(event({ testcases: [] }), {
+      createRunner: async () => echoingRunner,
+    })
+    expect(summary).toEqual({ totalScore: 0, maxScore: 0, results: [] })
+  })
+})

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -1,0 +1,354 @@
+import { createHash } from 'node:crypto'
+import { existsSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
+
+import type { AwsEvent, ConductorLibrary, Output, Summary, Testcase } from './index'
+
+/**
+ * Grades "conductor" programming questions. Unlike the legacy js-slang path,
+ * conductor questions carry a `(language, evaluator)` pair that is resolved via
+ * `@sourceacademy/language-directory` to an evaluator bundle (a browser Web
+ * Worker script published to GitHub Pages). We run that bundle headless in a
+ * Node `worker_threads` worker and drive it with the conductor host protocol
+ * (`@sourceacademy/conductor`).
+ *
+ * Scope: only pure-TypeScript evaluators (e.g. python-3 `cse`/PVML) are
+ * supported. Pyodide/WASM evaluators require a browser runtime and will surface
+ * as a run error here.
+ */
+
+const TIMEOUT_DURATION = process.env.TIMEOUT ? parseInt(process.env.TIMEOUT, 10) : 3000
+
+// The bundle requests its entry file back from the host; the name is only a
+// label (the host returns the assembled program regardless).
+const CONDUCTOR_ENTRYPOINT = '/program'
+
+// RunnerStatus values from @sourceacademy/conductor (terminal states).
+const RUNNER_STATUS_STOPPED = 5
+const RUNNER_STATUS_ERROR = 6
+
+/**
+ * The result of running one assembled program through a conductor evaluator.
+ * `output` is the accumulated stdout (python-3 CSE surfaces values via stdout,
+ * not the result channel); `result` is the final-value channel when an
+ * evaluator uses it.
+ */
+export type ConductorRunResult = {
+  output: string
+  result?: unknown
+  error?: string
+  timedOut: boolean
+}
+
+/** Runs a single assembled program and reports what it produced. */
+export type ConductorProgramRunner = (
+  program: string,
+  timeoutMs: number,
+) => Promise<ConductorRunResult>
+
+export type ConductorDeps = {
+  // Injectable for testing: given the conductor library, return a runner. The
+  // default resolves + fetches the evaluator bundle and runs it in a worker.
+  createRunner?: (library: ConductorLibrary) => Promise<ConductorProgramRunner>
+}
+
+// ESM interop: @sourceacademy/conductor and language-directory are ESM-only,
+// but this project compiles to CommonJS. A dynamic `import()` written normally
+// would be down-levelled by tsc to `require()` (which cannot load ESM), so it
+// is smuggled through the Function constructor to keep a native import at
+// runtime.
+const dynamicImport = new Function('specifier', 'return import(specifier)') as <T = unknown>(
+  specifier: string,
+) => Promise<T>
+
+type ConductorModules = {
+  Conduit: new (
+    link: unknown,
+    parent?: boolean,
+  ) => {
+    registerPlugin: (
+      pluginClass: unknown,
+      ...args: unknown[]
+    ) => { startEvaluator: (entry: string) => void }
+    terminate: () => void
+  }
+  BasicHostPlugin: new (conduit: unknown, channels: unknown) => unknown
+}
+
+let conductorModulesPromise: Promise<ConductorModules> | undefined
+
+function loadConductorModules(): Promise<ConductorModules> {
+  if (!conductorModulesPromise) {
+    conductorModulesPromise = Promise.all([
+      dynamicImport<{ Conduit: ConductorModules['Conduit'] }>('@sourceacademy/conductor/conduit'),
+      dynamicImport<{ BasicHostPlugin: ConductorModules['BasicHostPlugin'] }>(
+        '@sourceacademy/conductor/host',
+      ),
+    ]).then(([conduit, host]) => ({
+      Conduit: conduit.Conduit,
+      BasicHostPlugin: host.BasicHostPlugin,
+    }))
+  }
+  return conductorModulesPromise
+}
+
+/**
+ * Resolves a `(language, evaluator)` pair to the evaluator bundle URL using the
+ * bundled Source Academy language directory.
+ */
+async function resolveEvaluatorPath(language: string, evaluator: string): Promise<string> {
+  const directory = await dynamicImport<{
+    languageMap: Map<string, unknown>
+    getLanguageDefinition: (map: Map<string, unknown>, id: string) => unknown
+    getEvaluatorDefinition: (lang: unknown, id: string) => { path: string } | undefined
+  }>('@sourceacademy/language-directory')
+
+  const languageDefinition = directory.getLanguageDefinition(directory.languageMap, language)
+  if (!languageDefinition) {
+    throw new Error(`Unknown conductor language: "${language}"`)
+  }
+
+  const evaluatorDefinition = directory.getEvaluatorDefinition(languageDefinition, evaluator)
+  if (!evaluatorDefinition) {
+    throw new Error(`Unknown evaluator "${evaluator}" for conductor language "${language}"`)
+  }
+
+  return evaluatorDefinition.path
+}
+
+/** Fetches the evaluator bundle to a local cache file (reused across warm invocations). */
+async function fetchEvaluatorBundle(url: string): Promise<string> {
+  const cacheDir = process.env.CONDUCTOR_CACHE_DIR || tmpdir()
+  const digest = createHash('sha256').update(url).digest('hex').slice(0, 32)
+  const filePath = join(cacheDir, `conductor-evaluator-${digest}.js`)
+
+  if (existsSync(filePath)) {
+    return filePath
+  }
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch evaluator bundle (HTTP ${response.status}) from ${url}`)
+  }
+  writeFileSync(filePath, await response.text(), 'utf8')
+  return filePath
+}
+
+// Bootstrap executed inside the worker: the evaluator bundle is a browser Web
+// Worker IIFE that expects `self` to be the worker global (a MessagePort). Node's
+// parentPort is a Web-compatible MessagePort, so exposing it as `self` lets the
+// bundle initialise its conductor runner against it.
+const WORKER_BOOTSTRAP = `
+  const { parentPort, workerData } = require('worker_threads')
+  globalThis.self = parentPort
+  globalThis.window = globalThis
+  if (typeof parentPort.start === 'function') parentPort.start()
+  require(workerData.bundlePath)
+`
+
+/**
+ * Runs one assembled program through the evaluator bundle in a fresh worker,
+ * capturing stdout/result/errors. The worker is always terminated afterwards so
+ * runaway student code cannot outlive a single testcase.
+ */
+async function runConductorProgram(
+  bundlePath: string,
+  program: string,
+  timeoutMs: number,
+): Promise<ConductorRunResult> {
+  const { Conduit, BasicHostPlugin } = await loadConductorModules()
+
+  const outputs: string[] = []
+  let capturedResult: unknown
+  let capturedError: string | undefined
+  let workerError: string | undefined
+  let done = false
+
+  let markFinished!: () => void
+  const finished = new Promise<void>(resolve => {
+    markFinished = resolve
+  })
+  const settle = () => {
+    done = true
+    markFinished()
+  }
+
+  // BasicHostPlugin is loaded at runtime (ESM), so the host plugin subclass is
+  // defined here rather than at module scope.
+  const HostBase = BasicHostPlugin as new (
+    conduit: unknown,
+    channels: unknown,
+  ) => Record<string, unknown>
+  class NodeHostPlugin extends HostBase {
+    private readonly program: string
+
+    constructor(conduit: unknown, channels: unknown, program: string) {
+      super(conduit, channels)
+      this.program = program
+    }
+
+    requestFile(): Promise<string> {
+      return Promise.resolve(this.program)
+    }
+    requestLoadPlugin(): void {}
+    queryPluginResolutions(pluginId: string): Record<string, string> {
+      return { [pluginId]: pluginId }
+    }
+    receiveOutput(message: string): void {
+      outputs.push(message)
+    }
+    receiveResult(result: unknown): void {
+      if (result !== undefined) {
+        capturedResult = result
+      }
+    }
+    receiveError(error: unknown): void {
+      capturedError = extractErrorMessage(error)
+    }
+    receiveStatusUpdate(status: number): void {
+      if (status === RUNNER_STATUS_STOPPED || status === RUNNER_STATUS_ERROR) {
+        settle()
+      }
+    }
+  }
+
+  const worker = new Worker(WORKER_BOOTSTRAP, { eval: true, workerData: { bundlePath } })
+  worker.on('error', error => {
+    workerError = extractErrorMessage(error)
+    settle()
+  })
+
+  // Adapt Node's Worker (EventEmitter) to the conductor's Worker-shaped ILink.
+  const link = {
+    postMessage: (message: unknown, transfer?: unknown[]) =>
+      worker.postMessage(message, transfer as readonly [] | undefined),
+    addEventListener: (type: string, listener: (event: { data: unknown }) => void) =>
+      worker.on(type, (data: unknown) => listener({ data })),
+    terminate: () => {
+      void worker.terminate()
+    },
+  }
+
+  const conduit = new Conduit(link, true)
+  const host = conduit.registerPlugin(NodeHostPlugin, program)
+  host.startEvaluator(CONDUCTOR_ENTRYPOINT)
+
+  let timer: NodeJS.Timeout
+  const watchdog = new Promise<void>(resolve => {
+    timer = setTimeout(resolve, timeoutMs)
+  })
+  await Promise.race([finished, watchdog])
+  clearTimeout(timer!)
+
+  try {
+    conduit.terminate()
+  } catch {
+    // best-effort teardown
+  }
+  await worker.terminate()
+
+  return {
+    output: outputs.join(''),
+    result: capturedResult,
+    error: workerError ?? capturedError,
+    timedOut: !done,
+  }
+}
+
+async function defaultCreateRunner(library: ConductorLibrary): Promise<ConductorProgramRunner> {
+  const bundleUrl = await resolveEvaluatorPath(library.language, library.evaluator)
+  const bundlePath = await fetchEvaluatorBundle(bundleUrl)
+  return (program, timeoutMs) => runConductorProgram(bundlePath, program, timeoutMs)
+}
+
+/**
+ * Concatenates prepend + student + postpend + testcase into a single program.
+ * Conductor evaluators run one entry "file"; for the supported top-level
+ * languages the concatenation shares scope exactly like the legacy grader's
+ * shared context.
+ */
+export function assembleProgram(event: AwsEvent, testcase: Testcase): string {
+  return [event.prependProgram, event.studentProgram, event.postpendProgram, testcase.program]
+    .filter(part => typeof part === 'string' && part.length > 0)
+    .join('\n')
+}
+
+/** Trailing whitespace is dropped so a `print`-terminated newline still matches. */
+export function normalizeOutput(raw: string): string {
+  return raw.replace(/\s+$/u, '')
+}
+
+/** Turns a raw run into a graded {@link Output}. */
+export function gradeRun(run: ConductorRunResult, testcase: Testcase): Output {
+  if (run.error !== undefined) {
+    return {
+      resultType: 'error',
+      errors: [
+        {
+          errorType: 'runtime',
+          line: 0,
+          location: 'testcase',
+          errorLine: '',
+          errorExplanation: run.error,
+        },
+      ],
+    }
+  }
+
+  if (run.timedOut) {
+    return { resultType: 'error', errors: [{ errorType: 'timeout' }] }
+  }
+
+  const actualRaw =
+    run.output.length > 0 ? run.output : run.result === undefined ? '' : String(run.result)
+  const actual = normalizeOutput(actualRaw)
+  const expected = normalizeOutput(testcase.answer)
+
+  return actual === expected
+    ? { resultType: 'pass', score: testcase.score }
+    : { resultType: 'fail', expected: testcase.answer, actual }
+}
+
+/**
+ * Grades all testcases of a conductor programming question, returning the same
+ * {@link Summary} shape the backend expects for legacy questions.
+ */
+export const runAllConductor = async (
+  event: AwsEvent,
+  deps: ConductorDeps = {},
+): Promise<Summary> => {
+  const library = event.library as ConductorLibrary
+  const createRunner = deps.createRunner ?? defaultCreateRunner
+  const runProgram = await createRunner(library)
+
+  // Sequential: each testcase spins up its own worker, so we bound peak memory
+  // in the Lambda rather than running every evaluator bundle at once.
+  const results: Output[] = []
+  for (const testcase of event.testcases) {
+    const run = await runProgram(assembleProgram(event, testcase), TIMEOUT_DURATION)
+    results.push(gradeRun(run, testcase))
+  }
+
+  const totalScore = results.reduce<number>(
+    (total, result) => (result.resultType === 'pass' ? total + result.score : total),
+    0,
+  )
+  const maxScore = event.testcases.reduce<number>((max, testcase) => testcase.score + max, 0)
+
+  return { totalScore, maxScore, results }
+}
+
+function extractErrorMessage(error: unknown): string {
+  if (error == null) {
+    return 'Unknown conductor error'
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  if (typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message
+  }
+  return String(error)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
 import { Context, Frame, SourceError, Value, Variant } from 'js-slang/dist/types'
 import { stringify } from 'js-slang/dist/utils/stringify'
 
+import { runAllConductor } from './conductor'
 import { loadCurves, loadRunes } from './graphicsLoader'
 import { setupLambdaXvfb } from './setupXvfb'
 
@@ -16,11 +17,13 @@ Object.assign(externals, require('./tree.js'))
 const TIMEOUT_DURATION = process.env.TIMEOUT ? parseInt(process.env.TIMEOUT!, 10) : 3000 // in milliseconds
 
 /**
+ * The legacy Source-dialect library.
  * @property globals - an array of two element string arrays. The first element
  *   of this latter array is the identifier for the global var, and the second
  *   element is its javascript value (to be eval'd).
  */
-export type Library = {
+export type LegacyLibrary = {
+  format?: 'legacy'
   chapter: number
   external: {
     name: 'NONE' | 'RUNES' | 'CURVES' | 'SOUNDS' | 'BINARYTREES' | 'PIXNFLIX'
@@ -28,6 +31,18 @@ export type Library = {
   }
   globals: Array<string[]>
 }
+
+/**
+ * A conductor library: a language-agnostic `(language, evaluator)` pair
+ * resolved to an external runtime. It carries none of the legacy fields.
+ */
+export type ConductorLibrary = {
+  format: 'conductor'
+  language: string
+  evaluator: string
+}
+
+export type Library = LegacyLibrary | ConductorLibrary
 
 export type Testcase = {
   program: string
@@ -50,7 +65,7 @@ export type AwsEvent = {
  * Set of properties of a unit test
  */
 export type UnitTest = {
-  library: Library
+  library: LegacyLibrary
   prependProgram: string
   studentProgram: string
   postpendProgram: string
@@ -62,7 +77,7 @@ export type UnitTest = {
  * @property totalScore - the total score of the student program
  * @property results - the array of Output types
  */
-type Summary = {
+export type Summary = {
   totalScore: number
   maxScore: number
   results: Output[]
@@ -74,25 +89,25 @@ type Summary = {
  *  OutputFail - program raises no errors but answer is wrong
  *  OutputError - program raises an error
  */
-type Output = OutputPass | OutputFail | OutputError
+export type Output = OutputPass | OutputFail | OutputError
 
-type OutputPass = {
+export type OutputPass = {
   resultType: 'pass'
   score: number
 }
 
-type OutputFail = {
+export type OutputFail = {
   resultType: 'fail'
   expected: string
   actual: string
 }
 
-type OutputError = {
+export type OutputError = {
   resultType: 'error'
   errors: Array<ErrorFromSource | ErrorFromTimeout>
 }
 
-type ErrorFromSource = {
+export type ErrorFromSource = {
   errorType: 'runtime' | 'syntax'
   line: number
   location: 'prepend' | 'student' | 'postpend' | 'testcase' | 'unknown'
@@ -100,7 +115,7 @@ type ErrorFromSource = {
   errorExplanation: string
 }
 
-type ErrorFromTimeout = {
+export type ErrorFromTimeout = {
   errorType: 'timeout'
 }
 
@@ -120,8 +135,16 @@ type TimeoutResult = {
  * @param event the AwsEvent from the Backend
  */
 export const runAll = async (event: AwsEvent): Promise<Summary> => {
-  if (event.library && event.library.external) {
-    switch (event.library.external.name) {
+  // Conductor questions are graded by an external runtime, not js-slang. Branch
+  // before any legacy field (external/globals/chapter) is touched.
+  if (event.library && event.library.format === 'conductor') {
+    return runAllConductor(event)
+  }
+
+  const library = event.library as LegacyLibrary
+
+  if (library && library.external) {
+    switch (library.external.name) {
       case 'RUNES': {
         await setupLambdaXvfb()
         Object.assign(externals, await loadRunes())
@@ -138,10 +161,10 @@ export const runAll = async (event: AwsEvent): Promise<Summary> => {
     }
   }
 
-  evaluateGlobals(event.library.globals)
+  evaluateGlobals(library.globals)
   const promises: Promise<Output>[] = event.testcases.map((testcase: Testcase) =>
     run({
-      library: event.library,
+      library,
       prependProgram: event.prependProgram || '',
       studentProgram: event.studentProgram,
       postpendProgram: event.postpendProgram || '',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     "noUnusedLocals": true,
     "skipLibCheck": true
   },
+  "include": ["src"],
   "exclude": ["node_modules", "build", "dist"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,6 +821,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sourceacademy/conductor@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "@sourceacademy/conductor@npm:0.7.2"
+  checksum: 10c0/84cff73c8c67a5884c9a06774f514b2dc4275e14ee282c7eee4fd32618857f63cdc2a736c4e5d2b6501b7b39d6c9e2f7192af1dbbc8ec1542721c08252c1f022
+  languageName: node
+  linkType: hard
+
+"@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#0.0.13":
+  version: 0.0.13
+  resolution: "@sourceacademy/language-directory@https://github.com/source-academy/language-directory.git#commit=21808f59da7dc04637758e2377d0fce2cbb1299a"
+  checksum: 10c0/f98c279b96254497ee3454eab8e664b2fd725e4a9ad728d1fbc60767bf490d22c692d0d1ad2e90c8cf18d0dc579d5f1ab819ab7766b573730f9e28b081cfe961
+  languageName: node
+  linkType: hard
+
 "@ts-morph/bootstrap@npm:^0.18.0":
   version: 0.18.0
   resolution: "@ts-morph/bootstrap@npm:0.18.0"
@@ -2175,6 +2189,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "grader@workspace:."
   dependencies:
+    "@sourceacademy/conductor": "npm:^0.7.1"
+    "@sourceacademy/language-directory": "https://github.com/source-academy/language-directory.git#0.0.13"
     "@types/jest": "npm:^28.1.6"
     "@types/node": "npm:^25.0.3"
     coveralls: "npm:^3.1.1"


### PR DESCRIPTION
## What & why

Adds grading support for **conductor** (external-runtime) programming questions. Until now the backend refused to send them here; they carry a `(language, evaluator)` pair instead of the legacy `chapter`/`external`/`globals`.

Pairs with backend PR source-academy/backend#1367, which sends conductor answers to this grader as `library: { format: "conductor", language, evaluator }`.

## How it works

- `runAll` (`src/index.ts`) branches on `library.format === 'conductor'` to `runAllConductor` (`src/conductor.ts`) before any legacy field is touched.
- `runAllConductor` resolves the evaluator via `@sourceacademy/language-directory`, fetches + caches the published evaluator bundle, and runs it **headless in a Node `worker_threads` worker** driven by the `@sourceacademy/conductor` host protocol (a `self`/`ILink` shim + a `NodeHostPlugin`).
- Each testcase runs in a fresh worker (isolation + a wall-clock watchdog for runaway code). Grading compares the program's **stdout** to `testcase.answer` (python-3 CSE surfaces values via stdout, not the result channel). The response is the same `Summary` shape as the legacy path, so the backend parser is unchanged.

## Scope

- **python-3 pure-TypeScript evaluators only** (`cse` / PVML). Pyodide/WASM evaluators need a browser runtime and are deferred (they surface as a run error here).

## Verification

- `yarn test` — 48/48 (10 new conductor unit tests + existing suites), `yarn typecheck`, `yarn format:check`, `yarn build` all pass.
- End-to-end smoke (`scripts/smoke-conductor.cjs`, not in CI) run against the real `PyCseEvaluator3.js`: 4 python-3 testcases graded correctly (pass/pass/fail/runtime-error).

## Deploy notes

- The evaluator bundle is fetched from `source-academy.github.io` at runtime, so the Lambda needs outbound egress — or vendor the bundle at build time.
- Assessments must use real language-directory ids (e.g. `python3` / `python3Default`).

Draft: stacked on `richard/2601-maintenance` (depends on its Node 24 / build-script updates).